### PR TITLE
debugging is easier when errors aren't swallowed

### DIFF
--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -35,6 +35,6 @@ export function guard(fn:() => any) {
 	try {
 		fn()
 	} catch (err) {
-		return
+		console.warn(err)
 	}
 }

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -15,6 +15,7 @@ export function getValue<T>(fn:() => T,defaultValue:T = null):T {
 	try {
 		result = fn()
 	} catch (err) {
+		console.warn(err)
 	}
 	
 	if (isNil(result))


### PR DESCRIPTION
Reasoning: It can be more difficult to understand what's happening when errors are silenced.