### PR TITLE
slightly better type information for `isDefined`

### DIFF
--- a/src/Guards.ts
+++ b/src/Guards.ts
@@ -17,9 +17,7 @@ export function isNil(o:any):o is TNil {
  *
  * @param o
  */
-export function isDefined<T>(o:any):o is T
-export function isDefined(o:any):o is any
-export function isDefined(o:any) {
+export function isDefined<T>(o:T):o is T {
 	return !isNil(o)
 }
 


### PR DESCRIPTION
This small change provides more useful information when, for example, hovering on the `isDefined` call.

For example, try this [playground example](http://www.typescriptlang.org/play/#src=export%20type%20TNil%20%3D%20undefined%7Cnull%0A%0Adeclare%20function%20isNil(o%3Aany)%3Ao%20is%20TNil%0A%0Aexport%20function%20isDefined%3CT%3E(o%3Aany)%3Ao%20is%20T%20%7B%0A%09return%20!isNil(o)%0A%7D%0A%0A%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%0A%0Aconst%20test1%20%3D%20%7B%0A%20%20one%3A%201%0A%7D%0A%0Aif%20(isDefined(test1))%20%7B%0A%20%20%20%20test1.one%0A%7D%0Aelse%20%7B%20%0A%20%20%20%20test1.one%20%2F%2F%20should%20be%20a%20type%20error%0A%7D%0A%0A%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%0A%0Aconst%20test2%3A%20string%20%3D%20'asdfasdf'%0A%0Aif%20(isDefined(test2))%20%7B%0A%20%20%20%20test2.includes('asdf')%0A%7D%0Aelse%20%7B%20%0A%20%20%20%20test2.includes('asdf')%20%2F%2F%20should%20be%20a%20type%20error%0A%7D%0A%0A%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%0A%0Aconst%20test3%3A%20number%20%3D%20123%0A%0Aif%20(isDefined(test3))%20%7B%0A%20%20%20%20test3.toExponential(2)%0A%7D%0Aelse%20%7B%20%0A%20%20%20%20test3.toExponential(2)%20%2F%2F%20should%20be%20a%20type%20error%0A%7D) and hover on `isDefined` calls, then try hovering on the calls in [this one](http://www.typescriptlang.org/play/#src=export%20type%20TNil%20%3D%20undefined%7Cnull%0A%0Adeclare%20function%20isNil(o%3Aany)%3Ao%20is%20TNil%0A%0Aexport%20function%20isDefined%3CT%3E(o%3AT)%3Ao%20is%20T%20%7B%0A%09return%20!isNil(o)%0A%7D%0A%0A%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%0A%0Aconst%20test1%20%3D%20%7B%0A%20%20one%3A%201%0A%7D%0A%0Aif%20(isDefined(test1))%20%7B%0A%20%20%20%20test1.one%0A%7D%0Aelse%20%7B%20%0A%20%20%20%20test1.one%20%2F%2F%20should%20be%20a%20type%20error%0A%7D%0A%0A%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%0A%0Aconst%20test2%3A%20string%20%3D%20'asdfasdf'%0A%0Aif%20(isDefined(test2))%20%7B%0A%20%20%20%20test2.includes('asdf')%0A%7D%0Aelse%20%7B%20%0A%20%20%20%20test2.includes('asdf')%20%2F%2F%20should%20be%20a%20type%20error%0A%7D%0A%0A%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%0A%0Aconst%20test3%3A%20number%20%3D%20123%0A%0Aif%20(isDefined(test3))%20%7B%0A%20%20%20%20test3.toExponential(2)%0A%7D%0Aelse%20%7B%20%0A%20%20%20%20test3.toExponential(2)%20%2F%2F%20should%20be%20a%20type%20error%0A%7D).

Other than that, no difference in functionality. Just helps dev experience a small bit.